### PR TITLE
rm useless project in sln

### DIFF
--- a/shard.sln
+++ b/shard.sln
@@ -8,8 +8,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shard.Shared.Core", "Shard.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shard.API", "Shard.API\Shard.API.csproj", "{29313DDC-5C56-4403-B1CE-0BB2E6FBEF47}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shard.IntegrationTests", "Shard.IntegrationTests\Shard.IntegrationTests.csproj", "{E2F786D2-12AD-4FD2-992E-3E4BD8504E80}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{61ACBB34-498D-4401-90A0-2FC67071A743}"
 	ProjectSection(SolutionItems) = preProject
 		docker-compose.yml = docker-compose.yml


### PR DESCRIPTION
Shard.IntegrationTests\Shard.IntegrationTests.csproj is no longuer used, letting it is only crassing the build on server